### PR TITLE
Update postgres_exporter.go

### DIFF
--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -296,6 +296,7 @@ var builtinMetricMaps = map[string]intermediateMetricMap{
 			"stats_reset":        {DISCARD, "Time at which these statistics were last reset", nil, nil},
 			"last_archive_age":   {GAUGE, "Time in seconds since last WAL segment was successfully archived", nil, nil},
 		},
+		true,
 		0,
 	},
 	"pg_stat_activity": {


### PR DESCRIPTION
Fix the following error on build :

` # github.com/wrouesnel/postgres_exporter/cmd/postgres_exporter
cmd/postgres_exporter/postgres_exporter.go:299:3: cannot use 0 (type int) as type bool in field value
cmd/postgres_exporter/postgres_exporter.go:299:3: too few values in composite literal
Error: running "go build -a -ldflags -extldflags '-static' -X main.Version=v0.7.0-9-g2772da8 -o /go/src/github.com/wrouesnel/postgres_exporter/bin/postgres_exporter_v0.7.0_linux-amd64/postgres_exporter ./
cmd/postgres_exporter" failed with exit code 2
exit status 2`